### PR TITLE
use system make instead of self-built make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,8 +36,6 @@ build() {
     make install
 }
 
-export PATH="$TOP/vendor/make:$PATH"
-
 build skalibs
 build execline
 build s6

--- a/build.sh
+++ b/build.sh
@@ -36,9 +36,6 @@ build() {
     make install
 }
 
-set -x
-cd $(untar make)
-./configure && make
 export PATH="$TOP/vendor/make:$PATH"
 
 build skalibs

--- a/get_sources.sh
+++ b/get_sources.sh
@@ -12,11 +12,9 @@ url(){
 skalibs=$(url skalibs $skalibs_version)
 execline=$(url execline $execline_version)
 s6=$(url s6 $s6_version)
-make=http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
 
 set -x
 
-./get_package.sh make $make
 ./get_package.sh skalibs $skalibs
 ./get_package.sh execline $execline
 ./get_package.sh s6 $s6


### PR DESCRIPTION
This allows a greater likelihood of working. I wasn't able to build s6 on bionic with even my last change, but I made sure this change makes it build.